### PR TITLE
automatic_updating[chat space自動更新機能の実装]

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -73,7 +73,6 @@ $(function() {
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      console.log(messages)
       if (messages.length !== 0) {
         var insertHTML = '';
         $.each(messages, function(i, message) {
@@ -88,6 +87,6 @@ $(function() {
     });
   };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {
-    setInterval(reloadMessages, 700);
+    setInterval(reloadMessages, 7000);
   }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,44 +1,44 @@
 $(function() {
-      function buildHTML(message){
-        if ( message.image ) {
-          var html =
-           `<div class="message-info">
-              <div class="chat_main__message_nametime">
-                <div class="chat_main__message_user-name">
-                  ${message.user_name}
-                </div>
-                <div class="chat_main__message_time">
-                  ${message.created_at}
-                </div>
+    function buildHTML(message){
+      if ( message.image ) {
+        var html =
+          `<div class="message" data-message-id=${message.id}>
+            <div class="chat_main__message_nametime">
+              <div class="chat_main__message_user-name">
+                ${message.user_name}
               </div>
-              <div class="chat_main__message_coment">
-                <p class="lower-message__content">
-                  ${message.content}
-                </p>
+              <div class="chat_main__message_time">
+                ${message.created_at}
               </div>
-              <img src=${message.image} >
-            </div>`
-          return html;
-        } else {
-          var html =
-           `<div class="message-info">
-              <div class="chat_main__message_nametime">
-                <div class="chat_main__message_user-name">
-                  ${message.user_name}
-                </div>
-                <div class="chat_main__message_time">
-                  ${message.created_at}
-                </div>
+            </div>
+            <div class="chat_main__message_comment">
+              <p class="lower-message__content">
+                ${message.content}
+              </p>
+            </div>
+            <img src=${message.image} >
+          </div>`
+        return html;
+      } else {
+        var html =
+          `<div class="message" data-message-id=${message.id}>
+            <div class="chat_main__message_nametime">
+              <div class="chat_main__message_user-name">
+                ${message.user_name}
               </div>
-              <div class="chat_main__message_coment">
-                <p class="lower-message__content">
-                  ${message.content}
-                </p>
+              <div class="chat_main__message_time">
+                ${message.created_at}
               </div>
-            </div>`
-          return html;
-        };
-      }
+            </div>
+            <div class="chat_main__message_comment">
+              <p class="lower-message__content">
+                ${message.content}
+              </p>
+            </div>
+          </div>`
+        return html;
+      };
+    }
   $('#new_message').on('submit',function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -63,5 +63,31 @@ $(function() {
     .always(function() {
       $('.send_btn').prop('disabled', false);
     })
-  })
+  });
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log(messages)
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+      $('.chat_main__message_list').append(insertHTML);
+      $('.chat_main__message_list').animate({ scrollTop: $('.chat_main__message_list')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 700);
+  }
 });

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -142,7 +142,7 @@
     color: #999999;
     font-size: 12px;
   }
-  &__message_coment{
+  &__message_comment{
     color: #434a54;
     font-size: 14px;
     margin:12px 0px 46px 0px;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.to_s(:datetime)
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,10 +1,10 @@
-.message-info
+.message{data: {message: {id: message.id}}}
   .chat_main__message_nametime
     .chat_main__message_user-name
       = message.user.name
     .chat_main__message_time
       = message.created_at.to_s(:datetime)
-  .chat_main__message_coment
+  .chat_main__message_comment
     - if message.content.present?
       %p.lower-message__content
         = message.content

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image_url
 json.created_at @message.created_at.to_s(:datetime)
-json.content @message.content
-json.image @message.image_url
+json.user_name  @message.user.name
+json.id         @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
[why]
自動でチャットの画面が更新されるにはどうすれば良いのか理解する為。
また、自動で更新するのはチャット以外でも色んな場面で使われている筈なので、仕組みを理解していく為。

[what]
chat spaceの送信したメッセージをリアルタイムで自分で更新しなくても、自動で更新されるようにした。
・メッセージのidをカスタムデータ属性として追加
・apiディレクトリおよびコントローラを作成
・namespaceを利用したコントローラーのルーティング設定
・取得した最新のメッセージをブラウザのメッセージ一覧に追加
・setInterval()関数を利用して数秒毎に更新。

以下gyazoのgif動画です。確認お願いします。
※gyazoの収録時間が短いので更新時間の感覚を7000から700に変えて収録してます。
https://gyazo.com/23fa8ab320fb50db89cede867bbc4967